### PR TITLE
fix pad last block, now true by default

### DIFF
--- a/src/sd_embed/embedding_funcs.py
+++ b/src/sd_embed/embedding_funcs.py
@@ -117,7 +117,7 @@ def get_prompts_tokens_with_weights_t5(
 def group_tokens_and_weights(
     token_ids: list
     , weights: list
-    , pad_last_block = False
+    , pad_last_block = True
 ):
     """
     Produce tokens and weights in groups and pad the missing tokens


### PR DESCRIPTION
Hi! I believe you forgot pad last left block by mistake, this affected get_weighted_text_embeddings_sdxl_2p and refiner flow.
Pls letme know if im wrong
before/after padding last block (top 2 images): https://imgsli.com/MjgxMjM1
Cheers