### PR TITLE
Problem in embedding_funcs.py

### DIFF
--- a/src/sd_embed/embedding_funcs.py
+++ b/src/sd_embed/embedding_funcs.py
@@ -27,6 +27,7 @@ import math
 from diffusers import FluxPipeline
 from typing import Tuple
 import gc
+import typing
 
 def get_prompts_tokens_with_weights(
     clip_tokenizer: CLIPTokenizer
@@ -1023,7 +1024,7 @@ def get_weighted_text_embeddings_sdxl_2p(
 
 
 def get_weighted_text_embeddings_s_cascade(
-        pipe: type[StableCascadePriorPipeline | StableCascadeDecoderPipeline]
+        pipe: typing.Union[StableCascadePriorPipeline, StableCascadeDecoderPipeline]
         , prompt: str = ""
         , neg_prompt: str = ""
         , pad_last_block: bool = True

--- a/src/sd_embed/embedding_funcs.py
+++ b/src/sd_embed/embedding_funcs.py
@@ -1023,7 +1023,7 @@ def get_weighted_text_embeddings_sdxl_2p(
 
 
 def get_weighted_text_embeddings_s_cascade(
-        pipe: StableCascadePriorPipeline and StableCascadeDecoderPipeline
+        pipe: type[StableCascadePriorPipeline | StableCascadeDecoderPipeline]
         , prompt: str = ""
         , neg_prompt: str = ""
         , pad_last_block: bool = True

--- a/src/sd_embed/embedding_funcs.py
+++ b/src/sd_embed/embedding_funcs.py
@@ -1034,7 +1034,7 @@ def get_weighted_text_embeddings_s_cascade(
      for Stable Cascade
 
      Args:
-         pipe (StableCascadePriorPipeline and StableCascadeDecoderPipeline)
+         pipe (typing.Union[StableCascadePriorPipeline, StableCascadeDecoderPipeline])
          prompt (str)
          neg_prompt (str)
      Returns:

--- a/src/sd_embed/embedding_funcs.py
+++ b/src/sd_embed/embedding_funcs.py
@@ -1023,7 +1023,7 @@ def get_weighted_text_embeddings_sdxl_2p(
 
 
 def get_weighted_text_embeddings_s_cascade(
-        pipe: StableCascadePriorPipeline | StableCascadeDecoderPipeline
+        pipe: StableCascadePriorPipeline and StableCascadeDecoderPipeline
         , prompt: str = ""
         , neg_prompt: str = ""
         , pad_last_block: bool = True
@@ -1033,7 +1033,7 @@ def get_weighted_text_embeddings_s_cascade(
      for Stable Cascade
 
      Args:
-         pipe (StableCascadePriorPipeline | StableCascadeDecoderPipeline)
+         pipe (StableCascadePriorPipeline and StableCascadeDecoderPipeline)
          prompt (str)
          neg_prompt (str)
      Returns:


### PR DESCRIPTION
## Problem ⚠️

I'm running an image from `huggingface/transformers-pytorch-gpu` and when I download `sd_embed` and try to add it to the code, I get this error.

```bash
Traceback (most recent call last):
   File "app.py", line 10, in <module>
     from sd_embed.embedding_funcs import get_weighted_text_embeddings_sd15
   File "/usr/local/lib/python3.8/dist-packages/sd_embed/embedding_funcs.py", line 1026, in <module>
    pipe: StableCascadePriorPipeline | StableCascadeDecoderPipeline
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

## Solution 💡
So I just changed `|` to `and`.

## Test 🧪

**Dockerfile**

```dockerfile
FROM huggingface/transformers-pytorch-gpu:latest

RUN pip install torchao --extra-index-url https://download.pytorch.org/whl/cu121 # full options are cpu/cu118/cu121/cu124
RUN pip install git+https://github.com/cafesao/sd_embed.git@main

WORKDIR /app

CMD ["python3", "app.py"]
```

Create folder _/app_ and move `app.py` to folder.

**app.py**

```python
from sd_embed.embedding_funcs import get_weighted_text_embeddings_sd15

print("Hello Word")
```